### PR TITLE
Fix RIO assignment syntax in testbench

### DIFF
--- a/StdAES_Optimized_tb.v
+++ b/StdAES_Optimized_tb.v
@@ -97,8 +97,12 @@ module StdAES_Optimized_tb;
             round_cnt   <= 0;
         end else if (cycle_cnt < 8) begin
             for (i=0;i<8;i=i+1) begin
-                RIO[2*i]   <= IN[i+8] ^ {key_byte(0)[i],key_byte(2)[i],key_byte(4)[i],key_byte(6)[i],key_byte(8)[i],key_byte(10)[i],key_byte(12)[i],key_byte(14)[i]};
-                RIO[2*i+1] <= IN[i]   ^ {key_byte(1)[i],key_byte(3)[i],key_byte(5)[i],key_byte(7)[i],key_byte(9)[i],key_byte(11)[i],key_byte(13)[i],key_byte(15)[i]};
+                RIO[2*i]   <= { (key_byte(0))[i], (key_byte(2))[i], (key_byte(4))[i], (key_byte(6))[i],
+                                (key_byte(8))[i], (key_byte(10))[i], (key_byte(12))[i], (key_byte(14))[i] }
+                              ^ {8{IN[i+8]}};
+                RIO[2*i+1] <= { (key_byte(1))[i], (key_byte(3))[i], (key_byte(5))[i], (key_byte(7))[i],
+                                (key_byte(9))[i], (key_byte(11))[i], (key_byte(13))[i], (key_byte(15))[i] }
+                              ^ {8{IN[i]}};
             end
             cycle_cnt <= cycle_cnt + 1;
             if (cycle_cnt == 7)


### PR DESCRIPTION
## Summary
- Resolve syntax issues in RIO assignments by explicitly selecting key bits and replicating IN bits for XOR operations

## Testing
- `iverilog -g2012 StdAES_Optimized_tb.v StdAES_Optimized.v StdAES_Optimized_AES_Core.v StdAES_Optimized_MixColumns.v -o test.out` *(fails: command not found)*
- `apt-get install -y iverilog` *(fails: Unable to locate package iverilog)*

------
https://chatgpt.com/codex/tasks/task_e_689c94b9eb748322a30039b1feba71d7